### PR TITLE
fixed issues with shaders by setting the alpha channel to 1

### DIFF
--- a/XercaPaintMod/src/main/java/xerca/xercapaint/client/RenderEntityCanvas.java
+++ b/XercaPaintMod/src/main/java/xerca/xercapaint/client/RenderEntityCanvas.java
@@ -126,7 +126,7 @@ public class RenderEntityCanvas extends EntityRenderer<EntityCanvas> {
             int i = (color & 16711680) >> 16;
             int j = (color & '\uff00') >> 8;
             int k = (color & 255);
-            return k << 16 | j << 8 | i + 0xff000000;
+            return k << 16 | j << 8 | i | 0xff000000;
         }
 
         private void updateCanvasTexture(String name, int version) {

--- a/XercaPaintMod/src/main/java/xerca/xercapaint/client/RenderEntityCanvas.java
+++ b/XercaPaintMod/src/main/java/xerca/xercapaint/client/RenderEntityCanvas.java
@@ -126,7 +126,7 @@ public class RenderEntityCanvas extends EntityRenderer<EntityCanvas> {
             int i = (color & 16711680) >> 16;
             int j = (color & '\uff00') >> 8;
             int k = (color & 255);
-            return k << 16 | j << 8 | i;
+            return k << 16 | j << 8 | i + 0xff000000;
         }
 
         private void updateCanvasTexture(String name, int version) {


### PR DESCRIPTION
The alpha channel is not used in Vanilla (solid renderer). It is however used in shaders and will make paintings invisible. The fix also works for 1.18.2 and probably for every other version.