### PR TITLE
Always break paintings.

### DIFF
--- a/XercaPaintMod/src/main/java/xerca/xercapaint/entity/EntityCanvas.java
+++ b/XercaPaintMod/src/main/java/xerca/xercapaint/entity/EntityCanvas.java
@@ -118,11 +118,6 @@ public class EntityCanvas extends HangingEntity {
     public void dropItem(@Nullable Entity brokenEntity) {
         if (this.level().getGameRules().getBoolean(GameRules.RULE_DOENTITYDROPS)) {
             this.playSound(SoundEvents.PAINTING_BREAK, 1.0F, 1.0F);
-            if (brokenEntity instanceof Player playerentity) {
-                if (playerentity.getAbilities().instabuild) {
-                    return;
-                }
-            }
             ItemStack canvasItem;
             if(canvasType == CanvasType.SMALL){
                 canvasItem = new ItemStack(Items.ITEM_CANVAS);


### PR DESCRIPTION
Currently, paintings do not drop as items if the player that broke them has instabuild. When working in Creative, this can easily lead to situations where a single misclick can lose a painting forever. This removes that, and makes it so paintings drop regardless of player context and can always be retrieved.