### PR TITLE
Fix disconnect when logging in during music playback

### DIFF
--- a/XercaMusicMod/src/main/java/xerca/xercamusic/common/packets/clientbound/SingleNoteClientPacket.java
+++ b/XercaMusicMod/src/main/java/xerca/xercamusic/common/packets/clientbound/SingleNoteClientPacket.java
@@ -5,7 +5,6 @@ import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
-import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.player.Player;
 import org.jetbrains.annotations.NotNull;
@@ -14,7 +13,11 @@ import xerca.xercamusic.common.item.IItemInstrument;
 import xerca.xercamusic.common.item.Items;
 
 
-public record SingleNoteClientPacket(int note, IItemInstrument instrumentItem, Player playerEntity, boolean isStop, float volume) implements CustomPacketPayload {
+public record SingleNoteClientPacket(int note, IItemInstrument instrumentItem, int playerId, boolean isStop, float volume) implements CustomPacketPayload {
+    public SingleNoteClientPacket(int note, IItemInstrument instrumentItem, Player playerEntity, boolean isStop, float volume) {
+        this(note, instrumentItem, playerEntity.getId(), isStop, volume);
+    }
+
     public static final CustomPacketPayload.Type<SingleNoteClientPacket> PACKET_ID = new CustomPacketPayload.Type<>(Mod.id("single_note_client"));
     public static final StreamCodec<FriendlyByteBuf, SingleNoteClientPacket> PACKET_CODEC = StreamCodec.ofMember(SingleNoteClientPacket::encode, SingleNoteClientPacket::decode);
 
@@ -30,26 +33,30 @@ public record SingleNoteClientPacket(int note, IItemInstrument instrumentItem, P
                 throw new IndexOutOfBoundsException("Invalid instrumentId: " + instrumentId);
             }
 
-            ClientLevel level = Minecraft.getInstance().level;
-            if(level == null) {
-                return null;
-            }
-            Entity entity = level.getEntity(playerId);
-            if(!(entity instanceof Player playerEntity)){
-                throw new IndexOutOfBoundsException("Invalid playerId: " + playerId);
-            }
-
             IItemInstrument instrumentItem = Items.instruments[instrumentId];
-            return new SingleNoteClientPacket(note, instrumentItem, playerEntity, isStop, volume);
+            return new SingleNoteClientPacket(note, instrumentItem, playerId, isStop, volume);
         } catch (IndexOutOfBoundsException ioe) {
             Mod.LOGGER.error("Exception while reading SingleNotePacket:", ioe);
             return null;
         }
     }
 
+    public Player playerEntity() {
+        ClientLevel level = Minecraft.getInstance().level;
+        if(level == null) {
+            return null;
+        }
+
+        Entity entity = level.getEntity(playerId);
+        if(!(entity instanceof Player playerEntity)){
+            throw new IndexOutOfBoundsException("Invalid playerId: " + playerId);
+        }
+
+        return playerEntity;
+    }
+
     public FriendlyByteBuf encode(FriendlyByteBuf buf) {
         int instrumentId = instrumentItem.getInstrumentId();
-        int playerId = playerEntity.getId();
 
         buf.writeInt(note);
         buf.writeInt(instrumentId);

--- a/XercaMusicMod/src/main/java/xerca/xercamusic/common/packets/clientbound/TripleNoteClientPacket.java
+++ b/XercaMusicMod/src/main/java/xerca/xercamusic/common/packets/clientbound/TripleNoteClientPacket.java
@@ -5,7 +5,6 @@ import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
-import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.Entity;
 import org.jetbrains.annotations.NotNull;
 import xerca.xercamusic.common.Mod;
@@ -13,7 +12,11 @@ import xerca.xercamusic.common.item.IItemInstrument;
 import xerca.xercamusic.common.item.Items;
 
 
-public record TripleNoteClientPacket(int note1, int note2, int note3, IItemInstrument instrumentItem, Entity entity) implements CustomPacketPayload {
+public record TripleNoteClientPacket(int note1, int note2, int note3, IItemInstrument instrumentItem, int entityId) implements CustomPacketPayload {
+    public TripleNoteClientPacket(int note1, int note2, int note3, IItemInstrument instrumentItem, Entity entity) {
+        this(note1, note2, note3, instrumentItem, entity.getId());
+    }
+
     public static final CustomPacketPayload.Type<TripleNoteClientPacket> PACKET_ID = new CustomPacketPayload.Type<>(Mod.id("triple_note_client"));
     public static final StreamCodec<FriendlyByteBuf, TripleNoteClientPacket> PACKET_CODEC = StreamCodec.ofMember(TripleNoteClientPacket::encode, TripleNoteClientPacket::decode);
 
@@ -29,22 +32,24 @@ public record TripleNoteClientPacket(int note1, int note2, int note3, IItemInstr
                 throw new IndexOutOfBoundsException("Invalid instrumentId: " + instrumentId);
             }
 
-            ClientLevel level = Minecraft.getInstance().level;
-            if(level == null) {
-                return null;
-            }
-            Entity entity = level.getEntity(entityId);
             IItemInstrument instrumentItem = Items.instruments[instrumentId];
-            return new TripleNoteClientPacket(note1, note2, note3, instrumentItem, entity);
+            return new TripleNoteClientPacket(note1, note2, note3, instrumentItem, entityId);
         } catch (IndexOutOfBoundsException ioe) {
             Mod.LOGGER.error("Exception while reading SingleNotePacket:", ioe);
             return null;
         }
     }
 
+    public Entity entity() {
+        ClientLevel level = Minecraft.getInstance().level;
+        if(level == null) {
+            return null;
+        }
+        return level.getEntity(entityId);
+    }
+
     public FriendlyByteBuf encode(FriendlyByteBuf buf) {
         int instrumentId = instrumentItem.getInstrumentId();
-        int entityId = entity.getId();
 
         buf.writeInt(note1);
         buf.writeInt(note2);


### PR DESCRIPTION
Closes #158
Packets between 1.0.0 and this version will be compatible with each other. The main cause of this disconnect was due to trying to get a player entity in the network thread. As such, the player entity will be requested in the client thread instead, which ensures that the player it's requesting for does get loaded under Vanilla circumstances.

It's not an elegant solution however, as there's still a chance for the player to "not exist" on the player's side (/vanish mods for example), so more handling needs to be implemented for this to be a 100% solution, but this is still a good start.