### PR TITLE
Fix crash when placing piano block with Sinytra Connector

### DIFF
--- a/XercaMusicMod/src/main/java/xerca/xercamusic/common/item/ItemInstrument.java
+++ b/XercaMusicMod/src/main/java/xerca/xercamusic/common/item/ItemInstrument.java
@@ -70,7 +70,9 @@ public class ItemInstrument extends Item implements IItemInstrument {
         Level world = context.getLevel();
         BlockPos blockpos = context.getClickedPos();
         BlockState blockState = world.getBlockState(blockpos);
-        if (blockState.getBlock() == Blocks.MUSIC_BOX && !blockState.getValue(BlockMusicBox.HAS_INSTRUMENT)) {
+        if (blockState.getBlock() == Blocks.MUSIC_BOX && 
+                blockState.hasProperty(BlockMusicBox.HAS_INSTRUMENT) &&
+                    !blockState.getValue(BlockMusicBox.HAS_INSTRUMENT)) {
             ItemStack itemstack = context.getItemInHand();
             if (!world.isClientSide) {
                 BlockMusicBox.insertInstrument(world, blockpos, blockState, itemstack.getItem());


### PR DESCRIPTION
This PR fixes a critical game crash that occurs when placing down a piano block while using the latest version of Sinytra Connector.

Players using the latest Sinytra Connector were unable to place piano blocks without the game crashing. This change completely resolves that compatibility issue.

With this change,
   1) The piano block places successfully without crashing when using Sinytra Connector.
   2) This fix does not negatively affect or alter any existing base mod functionality.